### PR TITLE
Remove autoscaler from admissionwebhook ruleset

### DIFF
--- a/build/selectorsyncset.yaml
+++ b/build/selectorsyncset.yaml
@@ -327,16 +327,6 @@ objects:
           - '*/*'
           scope: '*'
         - apiGroups:
-          - autoscaling.openshift.io
-          apiVersions:
-          - '*'
-          operations:
-          - '*'
-          resources:
-          - clusterautoscalers
-          - machineautoscalers
-          scope: '*'
-        - apiGroups:
           - config.openshift.io
           apiVersions:
           - '*'


### PR DESCRIPTION
This makes ROSA/OSD cluster admins be able to configure clusterAutoScaler